### PR TITLE
Message Parser Array Index Error

### DIFF
--- a/models/STOMP/MessageParser.cfc
+++ b/models/STOMP/MessageParser.cfc
@@ -78,7 +78,7 @@ component {
 		var line = readNextLine();
 		while( line != "" ) {
 			var header = listToArray( line, ":" );
-			headers[ decode( header[ 1 ] ) ] = decode( header[ 2 ] );
+			headers[ decode( header[ 1 ] ) ] = decode( header[ 2 ] ?: "" );
 			line = readNextLine();
 		};
 		// if we reached here, we've hit the double line break after the headers, or the end of the message


### PR DESCRIPTION
In STOMP, if a header was sent with an empty value, such as `login:` or `passcode:`, the decode of the second position would fail as the array would come back as 1 position only.