### PR TITLE
fix: add curly braces to arrow function in WebSocketSTOMP for Adobe CF2023 compatibility

### DIFF
--- a/models/WebSocketSTOMP.cfc
+++ b/models/WebSocketSTOMP.cfc
@@ -150,7 +150,7 @@ component extends="WebSocketCore" {
 						};
 					
 						// Mix in our connection metadata with a prefix
-					connectionMetadata.each( (k,v)=> headers[ 'connectionMetadata-' & k ] = v );
+					connectionMetadata.each( (k,v)=> { headers[ 'connectionMetadata-' & k ] = v } );
 
 					var message2 = newMessage( "CONNECTED", headers ).validate();
 
@@ -479,7 +479,7 @@ component extends="WebSocketCore" {
 				STOMPSubscriptions = application.STOMPBroker.STOMPSubscriptions ?: {},
 				STOMPExchanges = {},
 				// Don't blow away connections if debugmode is on
-				STOMPConnections = application.STOMPBroker.STOMPConnections ?: {},
+				STOMPConnections = application.STOMPBroker.STOMPConnections ?: {}
 			};
 			
 


### PR DESCRIPTION
Problem:
Arrow function without curly braces on line 153 of WebSocketSTOMP.cfc causes an 
"Invalid CFML construct" error on Adobe ColdFusion.
and a dangling ',' on line 482

Fix:
Added curly braces to the arrow function body:

before:
connectionMetadata.each( (k,v)=> headers[ 'connectionMetadata-' & k ] = v );

after:
connectionMetadata.each( (k,v)=> { headers[ 'connectionMetadata-' & k ] = v } );

Tested on:
Adobe ColdFusion 2023